### PR TITLE
correct object comparison to avoid false positives/negatives

### DIFF
--- a/ECPAY_Payment_node_js/lib/ecpay_payment/verification.js
+++ b/ECPAY_Payment_node_js/lib/ecpay_payment/verification.js
@@ -327,7 +327,7 @@ class AioCheckOutParamVerify extends PaymentVerifyBase{
             Object.keys(ext_param).forEach(function (pa) {
                let val = params[pa];
                let related_required_param = ext_param[pa][val];
-               if (related_required_param !== undefined && related_required_param !== []){
+               if (related_required_param !== undefined){
                    related_required_param.forEach(function (e) {
                        if (!Object.keys(params).includes(e)){
                            throw new ECpayError.ECpayInvalidParam(`Lack required parameter [${e}] when [${pa}] is set to [${val}].`);
@@ -468,9 +468,6 @@ class AioCheckOutParamVerify extends PaymentVerifyBase{
                     let item_tax = params['InvoiceItemTaxType'].split('|');
                     let aval_tax_type = ['1', '2', '3'];
                     let vio_tax_t = item_tax - aval_tax_type;
-                    if (vio_tax_t === []){
-                        throw new ECpayError.ECpayInvoiceRuleViolate(`Illegal [InvoiceItemTaxType]: ${vio_tax_t}`);
-                    }
                     if (params['TaxType'] === '9'){
                         if (!item_tax.includes('1')){
                             throw new ECpayError.ECpayInvoiceRuleViolate(`[InvoiceItemTaxType] must contain at lease one '1'.`);


### PR DESCRIPTION
The following statement will always return 'true' since JavaScript compares objects by reference, not value.

```js
related_required_param !== []
```

The following statement will always return 'false' since JavaScript compares objects by reference, not value.

```js
if (vio_tax_t === []){
   ...
}
```