### PR TITLE
fix(helper): current date property

### DIFF
--- a/ECPAY_Payment_node_js/lib/ecpay_payment/helper.js
+++ b/ECPAY_Payment_node_js/lib/ecpay_payment/helper.js
@@ -20,8 +20,12 @@ class APIHelper {
         this.merc_id = this.merc_info.MerchantID
         this.hkey = this.merc_info.HashKey
         this.hiv = this.merc_info.HashIV
-        this.date = new Date();
     }
+
+    get date(){
+        return new Date()      
+    }
+    
     get_mercid(){
         return this.merc_id;
     }


### PR DESCRIPTION
This date property is used for getting the current unix time.

The previous version will prevent the use for singleton pattern where is will just return `RtnCode: 10200084` after 10 minutes passed. Therefore, it is changed to use a getter so that it is indeed getting the current time.